### PR TITLE
Add ENV hook for Ign Gazebo model path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,4 +32,7 @@ install(DIRECTORY
   DESTINATION share/${PROJECT_NAME}/
 )
 
+ament_environment_hooks(
+  "${CMAKE_CURRENT_SOURCE_DIR}/env-hooks/${PROJECT_NAME}.sh.in")
+
 ament_package()

--- a/env-hooks/franka_description.sh.in
+++ b/env-hooks/franka_description.sh.in
@@ -1,0 +1,3 @@
+ament_prepend_unique_value GAZEBO_MODEL_PATH "@CMAKE_INSTALL_PREFIX@/share"
+ament_prepend_unique_value GZ_SIM_RESOURCE_PATH "@CMAKE_INSTALL_PREFIX@/share"
+ament_prepend_unique_value IGN_GAZEBO_RESOURCE_PATH "@CMAKE_INSTALL_PREFIX@/share"


### PR DESCRIPTION
Adds environment hooks that automatically add Franka meshes to Ignition Gazebo's model path