### PR TITLE
Fix xacro file for FER

### DIFF
--- a/robots/fer/fer.urdf.xacro
+++ b/robots/fer/fer.urdf.xacro
@@ -49,4 +49,6 @@
                       use_fake_hardware="$(arg use_fake_hardware)"
                       fake_sensor_commands="$(arg fake_sensor_commands)"
                       gazebo_effort="$(arg gazebo_effort)">
+  </xacro:franka_robot>
+  
 </robot>


### PR DESCRIPTION
Fixes typo in `fer.urdf.xacro` file