### PR TITLE
Fixes to create_urdf.sh 

### DIFF
--- a/scripts/create_urdf.sh
+++ b/scripts/create_urdf.sh
@@ -5,7 +5,8 @@ docker build -t urdf_creation ./.docker
 echo 
 
 docker run -u 1001 \
-    -v $(pwd):/workspaces/src/franka_description \
+    -v "$(pwd):/workspaces/src/franka_description" \
     -w /workspaces/src/franka_description \
     urdf_creation \
     .docker/create_urdf.entrypoint.sh $*
+

--- a/scripts/create_urdf.sh
+++ b/scripts/create_urdf.sh
@@ -7,6 +7,7 @@ echo
 docker run -u 1001 \
     -v "$(pwd):/workspaces/src/franka_description" \
     -w /workspaces/src/franka_description \
+    --user "$(id -u):$(id -g)" \
     urdf_creation \
     .docker/create_urdf.entrypoint.sh $*
 


### PR DESCRIPTION
When trying to run create urdf.sh I encountered two issues. Firstly, the path I had installed had spaces in it. This caused an issue as the workspace path was unquoted.

Secondly, when running the command I faced a permissions issue when the code attempted to create the "urdfs" folder: 

```
[daniel@xps-15 franka_description]$ sudo ./scripts/create_urdf.sh --no-ee fr3
[+] Building 0.5s (11/11) FINISHED                                                                                           docker:default
 => [internal] load build definition from Dockerfile                                                                                   0.0s
 => => transferring dockerfile: 1.03kB                                                                                                 0.0s
 => [internal] load metadata for docker.io/osrf/ros:humble-desktop                                                                     0.3s
 => [internal] load .dockerignore                                                                                                      0.0s
 => => transferring context: 2B                                                                                                        0.0s
 => [1/7] FROM docker.io/osrf/ros:humble-desktop@sha256:4ffa1688825a525bcaf2f85684d95a0b351ef8b20e51d1356197ea17adef9ef8               0.0s
 => CACHED [2/7] WORKDIR /workspaces                                                                                                   0.0s
 => CACHED [3/7] RUN groupadd --gid 1001 user     && useradd --uid 1001 --gid 1001 -m user     && mkdir -p -m 0700 /run/user/"1001"    0.0s
 => CACHED [4/7] RUN apt-get update &&     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends     ros-humble-x  0.0s
 => CACHED [5/7] RUN echo "source /ros_entrypoint.sh" >>~/.bashrc                                                                      0.0s
 => CACHED [6/7] RUN echo "export ROS_DOMAIN_ID=100" >>~/.bashrc                                                                       0.0s
 => CACHED [7/7] RUN echo "set +e" >>~/.bashrc                                                                                         0.0s
 => exporting to image                                                                                                                 0.0s
 => => exporting layers                                                                                                                0.0s
 => => writing image sha256:eaeea15f793cd6c8ef1f565f1e0739921fb4170d7c6257f6f9f931c63cee1f07                                           0.0s
 => => naming to docker.io/library/urdf_creation                                                                                       0.0s

Traceback (most recent call last):
  File "/workspaces/src/franka_description/scripts/create_urdf.py", line 164, in <module>
    urdf_generation(package_path, xacro_file, file_name, WITH_SC, EE, HAND, robot)
  File "/workspaces/src/franka_description/scripts/create_urdf.py", line 53, in urdf_generation

*** WARNING: --no-ee argument will be removed in future releases, introducing none as ee id***

*** Creating URDF for fr3 ***
    save_urdf_to_file(package_path, urdf_file, file_name)
  File "/workspaces/src/franka_description/scripts/create_urdf.py", line 61, in save_urdf_to_file
    os.makedirs(folder_path)
  File "/usr/lib/python3.10/os.py", line 225, in makedirs
    mkdir(name, mode)
PermissionError: [Errno 13] Permission denied: '/workspaces/src/franka_description/urdfs'
```
This was fixed by specifying user id/group in the docker run call.