### PR TITLE
Prepare for Jazzy upgrade: Improve .docker/Dockerfile to only create users if not already present

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM osrf/ros:jazzy-desktop
+FROM osrf/ros:humble-desktop
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -19,7 +19,7 @@ RUN (getent group $USER_GID || groupadd --gid $USER_GID $USERNAME) \
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    ros-jazzy-xacro \
+    ros-jazzy-humble \
     ros-jazzy-joint-state-publisher-gui \
     && rm -rf /var/lib/apt/lists/*
 

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -8,6 +8,7 @@ ARG USERNAME=user
 
 WORKDIR /workspaces
 
+# Create user/group only of no such user/group exists
 RUN (getent group $USER_GID || groupadd --gid $USER_GID $USERNAME) \
     && (getent passwd $USER_UID || useradd --uid $USER_UID --gid $USER_GID -m $USERNAME) \
     && mkdir -p -m 0700 /run/user/"${USER_UID}" \

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM osrf/ros:humble-desktop
+FROM osrf/ros:jazzy-desktop
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -18,8 +18,8 @@ RUN groupadd --gid $USER_GID $USERNAME \
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    ros-humble-xacro \
-    ros-humble-joint-state-publisher-gui \
+    ros-jazzy-xacro \
+    ros-jazzy-joint-state-publisher-gui \
     && rm -rf /var/lib/apt/lists/*
 
 ENV XDG_RUNTIME_DIR=/run/user/"${USER_UID}"

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -20,7 +20,7 @@ RUN (getent group $USER_GID || groupadd --gid $USER_GID $USERNAME) \
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ros-jazzy-humble \
-    ros-jazzy-joint-state-publisher-gui \
+    ros-humble-joint-state-publisher-gui \
     && rm -rf /var/lib/apt/lists/*
 
 ENV XDG_RUNTIME_DIR=/run/user/"${USER_UID}"

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -19,7 +19,7 @@ RUN (getent group $USER_GID || groupadd --gid $USER_GID $USERNAME) \
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    ros-jazzy-humble \
+    ros-humble-xacro \
     ros-humble-joint-state-publisher-gui \
     && rm -rf /var/lib/apt/lists/*
 

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -8,13 +8,13 @@ ARG USERNAME=user
 
 WORKDIR /workspaces
 
-RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+RUN (getent group $USER_GID || groupadd --gid $USER_GID $USERNAME) \
+    && (getent passwd $USER_UID || useradd --uid $USER_UID --gid $USER_GID -m $USERNAME) \
     && mkdir -p -m 0700 /run/user/"${USER_UID}" \
     && mkdir -p -m 0700 /run/user/"${USER_UID}"/gdm \
-    && chown user:user /run/user/"${USER_UID}" \
-    && chown user:user /workspaces \
-    && chown user:user /run/user/"${USER_UID}"/gdm 
+    && chown $USER_UID:$USER_GID /run/user/"${USER_UID}" \
+    && chown $USER_UID:$USER_GID /workspaces \
+    && chown $USER_UID:$USER_GID /run/user/"${USER_UID}"/gdm 
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -24,7 +24,9 @@ RUN apt-get update && \
 
 ENV XDG_RUNTIME_DIR=/run/user/"${USER_UID}"
 
-USER $USERNAME
+# Specify user by UID & GID so this script doesn't
+# depend on the exact username
+USER $USER_UID:$USER_GID
 
 RUN echo "source /ros_entrypoint.sh" >>~/.bashrc
 ARG MAX_ROS_DOMAIN_ID=232


### PR DESCRIPTION
This set of minor changes to the Dockerfile allows using visualize_franka.sh with Jazzy, to avoid incompabitilies in a Jazzy-based setup.

Jazzy has UID/GID 1000 already used by the `ubuntu` user, so I implemented a *use existing group or create new group* logic, same for the UID. For details, see
https://techoverflow.net/2025/01/12/shell-logic-how-to-create-user-group-if-no-user-group-with-that-uid-gid-exists/

I only tested scripts/visualize_franka.sh, and only with `arm_id:=fr3`. All tests were performed with UID=1000 & GID=1000 on Ubuntu 24.04.