### PR TITLE
Changes parameter location in xacro:macro from 'arg' to 'property'

### DIFF
--- a/robots/fer/fer.urdf.xacro
+++ b/robots/fer/fer.urdf.xacro
@@ -45,6 +45,13 @@
   <!-- For a multi arm setup, we need a threaded robot running async-->
   <xacro:arg name="multi_arm" default="false" />
 
+  <!-- The prefix of the robot -->
+  <xacro:arg name="arm_prefix" default="" />
+
+  <!-- Append an underscore to the user-provided prefix, if non-empty. -->
+  <xacro:property name="prefix" value="$(arg arm_prefix)"/>
+  <xacro:property name="modified_prefix" value="${prefix + '_' if prefix else ''}"/>
+
   <xacro:franka_robot arm_id="fer"
                       joint_limits="${xacro.load_yaml('$(find franka_description)/robots/fer/joint_limits.yaml')}"
                       inertials="${xacro.load_yaml('$(find franka_description)/robots/fer/inertials.yaml')}"
@@ -60,7 +67,7 @@
                       fake_sensor_commands="$(arg fake_sensor_commands)"
                       gazebo_effort="$(arg gazebo_effort)"
                       no_prefix="$(arg no_prefix)"
-                      arm_prefix= ""
+                      arm_prefix= "${modified_prefix}"
                       connected_to= "base">
   </xacro:franka_robot>
 </robot>

--- a/robots/fp3/fp3.urdf.xacro
+++ b/robots/fp3/fp3.urdf.xacro
@@ -46,6 +46,10 @@
   <!-- For a multi arm setup, we need a threaded robot running async-->
   <xacro:arg name="multi_arm" default="false" />
 
+  <!-- Append an underscore to the user-provided prefix, if non-empty. -->
+  <xacro:property name="prefix" value="$(arg arm_prefix)"/>
+  <xacro:property name="modified_prefix" value="${prefix + '_' if prefix else ''}"/>
+
   <xacro:franka_robot arm_id="fp3"
                       joint_limits="${xacro.load_yaml('$(find franka_description)/robots/fp3/joint_limits.yaml')}"
                       inertials="${xacro.load_yaml('$(find franka_description)/robots/fp3/inertials.yaml')}"
@@ -61,7 +65,7 @@
                       fake_sensor_commands="$(arg fake_sensor_commands)"
                       gazebo_effort="$(arg gazebo_effort)"
                       no_prefix="$(arg no_prefix)"
-                      arm_prefix="$(arg arm_prefix)"
+                      arm_prefix= "${modified_prefix}"
                       connected_to= "base">
   </xacro:franka_robot>
 

--- a/robots/fr3/fr3.urdf.xacro
+++ b/robots/fr3/fr3.urdf.xacro
@@ -45,6 +45,10 @@
 
   <!-- For a multi arm setup, we need a threaded robot running async-->
   <xacro:arg name="multi_arm" default="false" />
+  
+  <!-- Append an underscore to the user-provided prefix, if non-empty. -->
+  <xacro:property name="prefix" value="$(arg arm_prefix)"/>
+  <xacro:property name="modified_prefix" value="${prefix + '_' if prefix else ''}"/>
 
   <xacro:franka_robot arm_id="fr3"
                       joint_limits="${xacro.load_yaml('$(find franka_description)/robots/fr3/joint_limits.yaml')}"


### PR DESCRIPTION
On `main` today, the `franka_robot` macro does not use its parameters. Instead, it uses XACRO arguments. I believe arguments are appropriate for `urdf.xacro` files, but `.xacro` files which should be _invoked_ by `urdf.xacro` files are functions of their parameters in most cases. 

This PR changes `franka_robot.xacro` to use its macro parameters, with the exception of `special_connection` which remains an argument.