### PR TITLE
Fix xacro syntax errors

### DIFF
--- a/robots/common/franka_arm.ros2_control.xacro
+++ b/robots/common/franka_arm.ros2_control.xacro
@@ -4,14 +4,14 @@
 <xacro:macro name="franka_arm_ros2_control"
          params="arm_id
              robot_ip
-             use_fake_hardware:=^|false
-             fake_sensor_commands:=^|false
-             gazebo:=^|false
-             hand:=^|false
-             gazebo_effort:=^|false
+             use_fake_hardware:=false
+             fake_sensor_commands:=false
+             gazebo:=false
+             hand:=false
+             gazebo_effort:=false
              arm_prefix:=''
              multi_arm:=false">
-             
+
     <xacro:property name="arm_prefix_modified" value="${'' if arm_prefix == '' else arm_prefix + '_'}" />
     <ros2_control name="${arm_prefix_modified}FrankaHardwareInterface" type="system">
         <hardware>

--- a/robots/common/franka_robot.xacro
+++ b/robots/common/franka_robot.xacro
@@ -13,15 +13,15 @@
                       ee_id:=none
                       gazebo:='false'
                       with_sc:='false'
-                      ros2_control:=false
+                      ros2_control:='false'
                       robot_ip:=''
-                      use_fake_hardware:=false
-                      fake_sensor_commands:=false
-                      gazebo_effort:=false
-                      no_prefix:='false'
+                      use_fake_hardware:='false'
+                      fake_sensor_commands:='false'
+                      gazebo_effort:='false'
+                      no_prefix:=''false''
                       arm_prefix:=''
                       connected_to:='base'
-                      multi_arm:=false">
+                      multi_arm:='false'">
     <xacro:include filename="$(find franka_description)/robots/common/utils.xacro" />
 
     <xacro:include filename="$(find franka_description)/robots/common/franka_arm.xacro" />
@@ -153,13 +153,13 @@
       <xacro:franka_arm_ros2_control
           arm_id="${arm_id}"
           robot_ip="${robot_ip}"
-          use_fake_hardware="$(arg use_fake_hardware)"
-          fake_sensor_commands="$(arg fake_sensor_commands)"
-          gazebo="$(arg gazebo)"
-          hand="$(arg hand)"
-          gazebo_effort="$(arg gazebo_effort)"
+          use_fake_hardware="${use_fake_hardware}"
+          fake_sensor_commands="${fake_sensor_commands}"
+          gazebo="${gazebo}"
+          hand="${hand}"
+          gazebo_effort="${gazebo_effort}"
           arm_prefix="${arm_prefix}"
-          multi_arm="$(arg multi_arm)"
+          multi_arm="${multi_arm}"
       />
     </xacro:if>
 


### PR DESCRIPTION
When I used the franka_robot macro in my own xacro file I got a bunch of errors about invalid xacro syntax. This is how I used the macro:

```xml
  <!-- Load Franka robot -->
  <xacro:include filename="$(find franka_description)/robots/common/franka_robot.xacro"/>
  <xacro:franka_robot arm_id="fr3"
                      joint_limits="${xacro.load_yaml('$(find franka_description)/robots/fr3/joint_limits.yaml')}"
                      inertials="${xacro.load_yaml('$(find franka_description)/robots/fr3/inertials.yaml')}"
                      kinematics="${xacro.load_yaml('$(find franka_description)/robots/fr3/kinematics.yaml')}"
                      dynamics="${xacro.load_yaml('$(find franka_description)/robots/fr3/dynamics.yaml')}"
                      rpy="$(arg rpy_ee)"
                      gazebo="false"
                      hand="true"
                      ee_id="$(arg ee_id)"
                      with_sc="false"
                      ros2_control="true"
                      robot_ip="172.16.0.2"
                      use_fake_hardware="false"
                      fake_sensor_commands="false"
                      gazebo_effort="false"
                      no_prefix="false"
                      arm_prefix=""
                      connected_to= "world">
  </xacro:franka_robot>
```
These changes fix it for me and where originally part of #11 but got removed right before the PR was merged:
https://github.com/frankaemika/franka_description/compare/eb82ecafc07c1f9a804c5af683e46e6edf4682a5..8a5522798a4843cb8f82cf6844233309c6be7d77
@jcarpinelli-bdai Why did you revert these changes? Did it work for you without them?