### PR TITLE
refactor: migrate to jazzy

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM osrf/ros:humble-desktop
+FROM osrf/ros:jazzy-desktop
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -18,8 +18,8 @@ RUN groupadd --gid $USER_GID $USERNAME \
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    ros-humble-xacro \
-    ros-humble-joint-state-publisher-gui \
+    ros-jazzy-xacro \
+    ros-jazzy-joint-state-publisher-gui \
     && rm -rf /var/lib/apt/lists/*
 
 ENV XDG_RUNTIME_DIR=/run/user/"${USER_UID}"

--- a/launch/visualize_franka.launch.py
+++ b/launch/visualize_franka.launch.py
@@ -14,13 +14,13 @@
 
 import os
 
-import xacro
 from ament_index_python.packages import get_package_share_directory
-from launch_ros.actions import Node
-
 from launch import LaunchContext, LaunchDescription
 from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
+
+from launch_ros.actions import Node
+import xacro
 
 
 def robot_state_publisher_spawner(context: LaunchContext, arm_id, load_gripper, ee_id):
@@ -28,40 +28,40 @@ def robot_state_publisher_spawner(context: LaunchContext, arm_id, load_gripper, 
     load_gripper_str = context.perform_substitution(load_gripper)
     ee_id_str = context.perform_substitution(ee_id)
     franka_xacro_filepath = os.path.join(
-        get_package_share_directory("franka_description"),
-        "robots",
+        get_package_share_directory('franka_description'),
+        'robots',
         arm_id_str,
-        arm_id_str + ".urdf.xacro",
+        arm_id_str + '.urdf.xacro',
     )
     robot_description = xacro.process_file(
-        franka_xacro_filepath, mappings={"hand": load_gripper_str, "ee_id": ee_id_str}
-    ).toprettyxml(indent="  ")
+        franka_xacro_filepath, mappings={'hand': load_gripper_str, 'ee_id': ee_id_str}
+    ).toprettyxml(indent='  ')
 
     return [
         Node(
-            package="robot_state_publisher",
-            executable="robot_state_publisher",
-            name="robot_state_publisher",
-            output="screen",
-            parameters=[{"robot_description": robot_description}],
+            package='robot_state_publisher',
+            executable='robot_state_publisher',
+            name='robot_state_publisher',
+            output='screen',
+            parameters=[{'robot_description': robot_description}],
         )
     ]
 
 
 def generate_launch_description():
-    load_gripper_parameter_name = "load_gripper"
+    load_gripper_parameter_name = 'load_gripper'
     load_gripper = LaunchConfiguration(load_gripper_parameter_name)
 
-    ee_id_parameter_name = "ee_id"
+    ee_id_parameter_name = 'ee_id'
     ee_id = LaunchConfiguration(ee_id_parameter_name)
 
-    arm_id_parameter_name = "arm_id"
+    arm_id_parameter_name = 'arm_id'
     arm_id = LaunchConfiguration(arm_id_parameter_name)
 
     rviz_file = os.path.join(
-        get_package_share_directory("franka_description"),
-        "rviz",
-        "visualize_franka.rviz",
+        get_package_share_directory('franka_description'),
+        'rviz',
+        'visualize_franka.rviz',
     )
 
     robot_state_publisher_spawner_opaque_function = OpaqueFunction(
@@ -72,32 +72,32 @@ def generate_launch_description():
         [
             DeclareLaunchArgument(
                 load_gripper_parameter_name,
-                default_value="true",
-                description="Use end-effector if true. Default value is franka hand. "
-                "Robot is loaded without end-effector otherwise",
+                default_value='true',
+                description='Use end-effector if true. Default value is franka hand. '
+                'Robot is loaded without end-effector otherwise',
             ),
             DeclareLaunchArgument(
                 ee_id_parameter_name,
-                default_value="franka_hand",
-                description="ID of the type of end-effector used. Supporter values: "
-                "none, franka_hand, cobot_pump",
+                default_value='franka_hand',
+                description='ID of the type of end-effector used. Supporter values: '
+                'none, franka_hand, cobot_pump',
             ),
             DeclareLaunchArgument(
                 arm_id_parameter_name,
-                description="ID of the type of arm used. Supporter values: "
-                "fer, fr3, fp3, fr3v2",
+                description='ID of the type of arm used. Supporter values: '
+                'fer, fr3, fp3, fr3v2',
             ),
             robot_state_publisher_spawner_opaque_function,
             Node(
-                package="joint_state_publisher_gui",
-                executable="joint_state_publisher_gui",
-                name="joint_state_publisher_gui",
+                package='joint_state_publisher_gui',
+                executable='joint_state_publisher_gui',
+                name='joint_state_publisher_gui',
             ),
             Node(
-                package="rviz2",
-                executable="rviz2",
-                name="rviz2",
-                arguments=["--display-config", rviz_file],
+                package='rviz2',
+                executable='rviz2',
+                name='rviz2',
+                arguments=['--display-config', rviz_file],
             ),
         ]
     )

--- a/launch/visualize_franka_duo.launch.py
+++ b/launch/visualize_franka_duo.launch.py
@@ -14,13 +14,13 @@
 
 import os
 
-import xacro
 from ament_index_python.packages import get_package_share_directory
-from launch_ros.actions import Node
-
 from launch import LaunchContext, LaunchDescription
 from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
+
+from launch_ros.actions import Node
+import xacro
 
 
 def robot_state_publisher_spawner(context: LaunchContext, arm_id, arm_prefix, load_gripper, ee_id):
@@ -29,70 +29,70 @@ def robot_state_publisher_spawner(context: LaunchContext, arm_id, arm_prefix, lo
     load_gripper_str = context.perform_substitution(load_gripper)
     ee_id_str = context.perform_substitution(ee_id)
     franka_xacro_filepath = os.path.join(
-        get_package_share_directory("franka_description"),
-        "robots",
-        "fr3_duo",
-        "fr3_duo_" + arm_id_str + ".urdf.xacro",
+        get_package_share_directory('franka_description'),
+        'robots',
+        'fr3_duo',
+        'fr3_duo_' + arm_id_str + '.urdf.xacro',
     )
 
-    if arm_id_str == "fixed_structure":
-        robot_description = xacro.process_file(franka_xacro_filepath).toprettyxml(indent="  ")
+    if arm_id_str == 'fixed_structure':
+        robot_description = xacro.process_file(franka_xacro_filepath).toprettyxml(indent='  ')
     else:
         robot_description = xacro.process_file(
             franka_xacro_filepath,
             mappings={
-                "hand": load_gripper_str,
-                "ee_id": ee_id_str,
-                "arm_prefix": arm_prefix_str
+                'hand': load_gripper_str,
+                'ee_id': ee_id_str,
+                'arm_prefix': arm_prefix_str
             }
-        ).toprettyxml(indent="  ")
+        ).toprettyxml(indent='  ')
 
     return [
         Node(
-            package="robot_state_publisher",
-            executable="robot_state_publisher",
-            name="robot_state_publisher_" + arm_id_str + "_" + arm_prefix_str,
-            namespace=arm_id_str + "_" + arm_prefix_str,
-            output="screen",
-            parameters=[{"robot_description": robot_description}],
+            package='robot_state_publisher',
+            executable='robot_state_publisher',
+            name='robot_state_publisher_' + arm_id_str + '_' + arm_prefix_str,
+            namespace=arm_id_str + '_' + arm_prefix_str,
+            output='screen',
+            parameters=[{'robot_description': robot_description}],
         ),
         Node(
-                package="joint_state_publisher_gui",
-                executable="joint_state_publisher_gui",
-                name="joint_state_publisher_gui",
-                namespace=arm_id_str + "_" + arm_prefix_str,
+                package='joint_state_publisher_gui',
+                executable='joint_state_publisher_gui',
+                name='joint_state_publisher_gui',
+                namespace=arm_id_str + '_' + arm_prefix_str,
             ),
     ]
 
 
 def generate_launch_description():
-    load_gripper_parameter_name = "load_gripper"
+    load_gripper_parameter_name = 'load_gripper'
     load_gripper = LaunchConfiguration(load_gripper_parameter_name)
 
-    ee_id_parameter_name = "ee_id"
+    ee_id_parameter_name = 'ee_id'
     ee_id = LaunchConfiguration(ee_id_parameter_name)
 
-    arm_id_parameter_name = "arm_id"
+    arm_id_parameter_name = 'arm_id'
     arm_id = LaunchConfiguration(arm_id_parameter_name)
 
     rviz_file = os.path.join(
-        get_package_share_directory("franka_description"),
-        "rviz",
-        "visualize_franka_duo.rviz",
+        get_package_share_directory('franka_description'),
+        'rviz',
+        'visualize_franka_duo.rviz',
     )
 
     robot_state_publisher_spawner_opaque_function = []
-    fr3_duo_components = ["fixed_structure", "arm_left", "arm_right"]
+    fr3_duo_components = ['fixed_structure', 'arm_left', 'arm_right']
     for component in fr3_duo_components:
-        if component == "fixed_structure":
-            print("Spawning fixed structure")
+        if component == 'fixed_structure':
+            print('Spawning fixed structure')
             robot_state_publisher_spawner_opaque_function.append(OpaqueFunction(
-                function=robot_state_publisher_spawner, args=[component, "", load_gripper, ee_id]
+                function=robot_state_publisher_spawner, args=[component, '', load_gripper, ee_id]
             ))
         else:
-            print("Spawning arm")
-            arm_id = component.split("_")[0]
-            arm_prefix = component.split("_")[1]
+            print('Spawning arm')
+            arm_id = component.split('_')[0]
+            arm_prefix = component.split('_')[1]
             robot_state_publisher_spawner_opaque_function.append(OpaqueFunction(
                 function=robot_state_publisher_spawner,
                 args=[arm_id, arm_prefix, load_gripper, ee_id]
@@ -102,27 +102,27 @@ def generate_launch_description():
         [
             DeclareLaunchArgument(
                 load_gripper_parameter_name,
-                default_value="true",
-                description="Use end-effector if true. Default value is franka hand. "
-                "Robot is loaded without end-effector otherwise",
+                default_value='true',
+                description='Use end-effector if true. Default value is franka hand. '
+                'Robot is loaded without end-effector otherwise',
             ),
             DeclareLaunchArgument(
                 ee_id_parameter_name,
-                default_value="franka_hand",
-                description="ID of the type of end-effector used. Supporter values: "
-                "none, franka_hand, cobot_pump",
+                default_value='franka_hand',
+                description='ID of the type of end-effector used. Supporter values: '
+                'none, franka_hand, cobot_pump',
             ),
             DeclareLaunchArgument(
                 arm_id_parameter_name,
-                description="ID of the type of arm used. Supporter values: "
-                "fer, fr3, fp3, fr3v2, fr3_duo",
+                description='ID of the type of arm used. Supporter values: '
+                'fer, fr3, fp3, fr3v2, fr3_duo',
             ),
             *robot_state_publisher_spawner_opaque_function,
             Node(
-                package="rviz2",
-                executable="rviz2",
-                name="rviz2",
-                arguments=["--display-config", rviz_file],
+                package='rviz2',
+                executable='rviz2',
+                name='rviz2',
+                arguments=['--display-config', rviz_file],
             ),
         ]
     )

--- a/robots/common/franka_arm.ros2_control.xacro
+++ b/robots/common/franka_arm.ros2_control.xacro
@@ -18,13 +18,13 @@
           <param name="arm_id">${arm_id}</param>
           <param name="prefix">${arm_prefix}</param>
           <xacro:if value="${use_fake_hardware}">
-            <plugin>fake_components/GenericSystem</plugin>
+            <plugin>mock_components/GenericSystem</plugin>
             <param name="fake_sensor_commands">${fake_sensor_commands}</param>
             <param name="state_following_offset">0.0</param>
           </xacro:if>
 
           <xacro:if value="${gazebo}">
-            <plugin>franka_ign_ros2_control/IgnitionSystem</plugin>
+            <plugin>franka_gz_ros2_control/GZSystem</plugin>
           </xacro:if>
 
           <xacro:if value="${use_fake_hardware == 0 and gazebo == 0}">
@@ -103,7 +103,7 @@
     </ros2_control>
     <xacro:if value="${gazebo}">
       <gazebo>
-        <plugin filename="franka_ign_ros2_control-system" name="ign_ros2_control::IgnitionROS2ControlPlugin">
+        <plugin filename="franka_gz_ros2_control-system" name="gz_ros2_control::GZROS2ControlPlugin">
           <parameters>$(find franka_gazebo_bringup)/config/franka_gazebo_controllers.yaml</parameters>
         </plugin>
       </gazebo>

--- a/scripts/create_urdf.py
+++ b/scripts/create_urdf.py
@@ -19,30 +19,30 @@ import xacro
 
 
 def str_to_bool(s):
-    return s.lower() in ["true", "1", "yes", "y"]
+    return s.lower() in ['true', '1', 'yes', 'y']
 
 
 def convert_xacro_to_urdf(xacro_file, only_ee, with_sc, ee_id, hand, no_prefix, robot):
     """Convert xacro file into a URDF file."""
     mappings = {
-        "with_sc": str(with_sc),
-        "ee_id": str(ee_id),
-        "hand": str(hand),
-        "no_prefix": str(no_prefix),
-        "arm_id": str(robot),
+        'with_sc': str(with_sc),
+        'ee_id': str(ee_id),
+        'hand': str(hand),
+        'no_prefix': str(no_prefix),
+        'arm_id': str(robot),
     }
 
-    if only_ee and robot == "":
-        mappings["connection"] = ""
+    if only_ee and robot == '':
+        mappings['connection'] = ''
 
     urdf = xacro.process_file(xacro_file, mappings=mappings)
-    urdf_file = urdf.toprettyxml(indent="  ")
+    urdf_file = urdf.toprettyxml(indent='  ')
     return urdf_file
 
 
 def convert_package_name_to_absolute_path(package_name, package_path, urdf_file):
     """Replace a ROS package names with the absolute paths."""
-    urdf_file = urdf_file.replace("package://{}".format(package_name), package_path)
+    urdf_file = urdf_file.replace('package://{}'.format(package_name), package_path)
     return urdf_file
 
 
@@ -56,39 +56,39 @@ def urdf_generation(
     HAND,
     NO_PREFIX,
     robot,
-    description_type="urdf",
+    description_type='urdf',
 ):
     """Generate URDF file and save it."""
     xacro_file = os.path.join(package_path, xacro_file)
     urdf_file = convert_xacro_to_urdf(xacro_file, ONLY_EE, WITH_SC, EE, HAND, NO_PREFIX, robot)
-    if ABSOLUTE_PATHS and (HOST_DIR is None or HOST_DIR == ""):
+    if ABSOLUTE_PATHS and (HOST_DIR is None or HOST_DIR == ''):
         urdf_file = convert_package_name_to_absolute_path(package_name, package_path, urdf_file)
     elif ABSOLUTE_PATHS:
         urdf_file = convert_package_name_to_absolute_path(package_name, HOST_DIR, urdf_file)
     save_urdf_to_file(package_path, urdf_file, file_name, description_type)
 
 
-def save_urdf_to_file(package_path, urdf_file, robot, description_type="urdf"):
+def save_urdf_to_file(package_path, urdf_file, robot, description_type='urdf'):
     """Save URDF into a file."""
     # Check if the folder exists, and if not, create it
-    folder_path = f"{package_path}/urdfs"
+    folder_path = f'{package_path}/urdfs'
     if not os.path.exists(folder_path):
         os.makedirs(folder_path)
 
-    with open(f"{package_path}/urdfs/{robot}.{description_type}", "w") as f:
+    with open(f'{package_path}/urdfs/{robot}.{description_type}', 'w') as f:
         f.write(urdf_file)
 
 
-if __name__ == "__main__":
-    package_name = "franka_description"
+if __name__ == '__main__':
+    package_name = 'franka_description'
 
-    if os.getcwd().split("/")[-1] != package_name:
-        print("Call the script from franka_description root folder")
+    if os.getcwd().split('/')[-1] != package_name:
+        print('Call the script from franka_description root folder')
         exit()
 
-    ROBOTS = ["fr3v2", "fr3_duo", "fr3", "fp3", "fer"]
+    ROBOTS = ['fr3v2', 'fr3_duo', 'fr3', 'fp3', 'fer']
 
-    END_EFFECTORS = ["none", "franka_hand", "cobot_pump"]
+    END_EFFECTORS = ['none', 'franka_hand', 'cobot_pump']
 
     parser = argparse.ArgumentParser(
         description="""
@@ -97,45 +97,45 @@ if __name__ == "__main__":
             """
     )
 
-    robots_str = ", ".join([f"{item}" for item in ROBOTS])
+    robots_str = ', '.join([f'{item}' for item in ROBOTS])
     parser.add_argument(
-        "robot_model",
+        'robot_model',
         type=str,
-        nargs="?",
-        default="",
-        help="id of the robot model (accepted values are: {})".format(robots_str),
+        nargs='?',
+        default='',
+        help='id of the robot model (accepted values are: {})'.format(robots_str),
     )
     parser.add_argument(
-        "--no-ee",
-        help="Disable loading of end-effector.",
-        action="store_const",
+        '--no-ee',
+        help='Disable loading of end-effector.',
+        action='store_const',
         const=True,
     )
-    ee_str = ", ".join([f"{item}" for item in END_EFFECTORS])
+    ee_str = ', '.join([f'{item}' for item in END_EFFECTORS])
     parser.add_argument(
-        "--robot-ee",
+        '--robot-ee',
         type=str,
-        default="franka_hand",
-        help="id of the robot end effector (accepted values are: {})".format(ee_str),
+        default='franka_hand',
+        help='id of the robot end effector (accepted values are: {})'.format(ee_str),
     )
     parser.add_argument(
-        "--with-sc",
-        help="Include self-collision volumes in the urdf model.",
-        action="store_const",
+        '--with-sc',
+        help='Include self-collision volumes in the urdf model.',
+        action='store_const',
         const=True,
     )
-    parser.add_argument("--abs-path", help="Use absolute paths.", action="store_const", const=True)
-    parser.add_argument("--host-dir", help="Provide a host directory for the absolute path.")
+    parser.add_argument('--abs-path', help='Use absolute paths.', action='store_const', const=True)
+    parser.add_argument('--host-dir', help='Provide a host directory for the absolute path.')
     parser.add_argument(
-        "--only-ee",
-        help="Get urdf with solely end-effector data.",
-        action="store_const",
+        '--only-ee',
+        help='Get urdf with solely end-effector data.',
+        action='store_const',
         const=True,
     )
     parser.add_argument(
-        "--no-prefix",
-        help="Override the robot prefix of links, joints and visuals in the urdf file.",
-        action="store_const",
+        '--no-prefix',
+        help='Override the robot prefix of links, joints and visuals in the urdf file.',
+        action='store_const',
         const=True,
     )
 
@@ -143,27 +143,27 @@ if __name__ == "__main__":
 
     ROBOT_MODEL = args.robot_model.lower()
     HAND = not args.no_ee
-    EE = args.robot_ee.lower() if args.robot_ee is not None else "franka_hand"
+    EE = args.robot_ee.lower() if args.robot_ee is not None else 'franka_hand'
     WITH_SC = args.with_sc if args.with_sc is not None else False
     ABSOLUTE_PATHS = args.abs_path if args.abs_path is not None else False
     HOST_DIR = args.host_dir
     ONLY_EE = args.only_ee if args.only_ee is not None else False
-    NO_PREFIX = args.no_prefix if args.no_prefix is not None else "false"
+    NO_PREFIX = args.no_prefix if args.no_prefix is not None else 'false'
 
     assert (
-        ROBOT_MODEL in ROBOTS or ROBOT_MODEL == "all" or ROBOT_MODEL == "none" or ROBOT_MODEL == ""
+        ROBOT_MODEL in ROBOTS or ROBOT_MODEL == 'all' or ROBOT_MODEL == 'none' or ROBOT_MODEL == ''
     )
 
-    if ROBOT_MODEL != "all" and ROBOT_MODEL != "none":
+    if ROBOT_MODEL != 'all' and ROBOT_MODEL != 'none':
         ROBOTS = [ROBOT_MODEL]
 
     package_path = os.getcwd()
     if ONLY_EE:
-        print(f"\n*** Creating URDF for {EE} ***")
-        xacro_file = f"end_effectors/{EE}/{EE}.urdf.xacro"
-        file_name = f"{EE}"
-        if ROBOT_MODEL == "all" or ROBOT_MODEL == "none" or ROBOT_MODEL == "":
-            robot_prefix = ""
+        print(f'\n*** Creating URDF for {EE} ***')
+        xacro_file = f'end_effectors/{EE}/{EE}.urdf.xacro'
+        file_name = f'{EE}'
+        if ROBOT_MODEL == 'all' or ROBOT_MODEL == 'none' or ROBOT_MODEL == '':
+            robot_prefix = ''
         else:
             robot_prefix = ROBOT_MODEL
         urdf_generation(
@@ -178,26 +178,26 @@ if __name__ == "__main__":
             robot_prefix,
         )
     else:
-        if ROBOT_MODEL == "none" or ROBOT_MODEL == "":
-            print("\n*** Robot model must be specified ***")
+        if ROBOT_MODEL == 'none' or ROBOT_MODEL == '':
+            print('\n*** Robot model must be specified ***')
         else:
             for robot in ROBOTS:
-                description_types = ["urdf", "srdf"]
+                description_types = ['urdf', 'srdf']
                 for description_type in description_types:
-                    if description_type == "srdf" and robot == "fr3_duo":
+                    if description_type == 'srdf' and robot == 'fr3_duo':
                         continue
-                    xacro_file = f"robots/{robot}/{robot}.{description_type}.xacro"
-                    if HAND and EE != "none":
-                        print(f"\n*** Creating {description_type} for {robot} and {EE} ***")
-                        file_name = f"{robot}_{EE}"
+                    xacro_file = f'robots/{robot}/{robot}.{description_type}.xacro'
+                    if HAND and EE != 'none':
+                        print(f'\n*** Creating {description_type} for {robot} and {EE} ***')
+                        file_name = f'{robot}_{EE}'
                     else:
                         if not HAND:
                             print(
-                                "\n*** WARNING: --no-ee argument will be removed in future"
-                                " releases, introducing none as ee id***"
+                                '\n*** WARNING: --no-ee argument will be removed in future'
+                                ' releases, introducing none as ee id***'
                             )
-                        print(f"\n*** Creating {description_type} for {robot} ***")
-                        file_name = f"{robot}"
+                        print(f'\n*** Creating {description_type} for {robot} ***')
+                        file_name = f'{robot}'
                     urdf_generation(
                         package_path,
                         xacro_file,

--- a/test/urdf_tests.py
+++ b/test/urdf_tests.py
@@ -14,16 +14,16 @@
 
 from os import path
 
-import xacro
 from ament_index_python.packages import get_package_share_directory
+import xacro
 
-arm_id_ = "fer"
+arm_id_ = 'fer'
 
 xacro_file_name = path.join(
-    get_package_share_directory("franka_description"),
-    "robots",
+    get_package_share_directory('franka_description'),
+    'robots',
     arm_id_,
-    arm_id_ + ".urdf.xacro",
+    arm_id_ + '.urdf.xacro',
 )
 
 
@@ -32,49 +32,49 @@ def test_load():
     urdf = xacro.process_file(
         xacro_file_name,
         mappings={
-            "arm_id": "fer",
-            "ee_id": "none",
+            'arm_id': 'fer',
+            'ee_id': 'none',
         },
     ).toxml()
-    assert urdf.find("fer_finger_joint1") == -1
+    assert urdf.find('fer_finger_joint1') == -1
 
 
 def test_load_with_gripper():
     """Test of hand parameter equal to a value."""
     urdf = xacro.process_file(
-        xacro_file_name, mappings={"arm_id": "fer", "ee_id": "franka_hand"}
+        xacro_file_name, mappings={'arm_id': 'fer', 'ee_id': 'franka_hand'}
     ).toxml()
-    assert urdf.find("fer_finger_joint") != -1
+    assert urdf.find('fer_finger_joint') != -1
 
 
 def test_check_interfaces():
     """Test of the parameters for ros2_control hardware interface."""
     urdf = xacro.process_file(
-        xacro_file_name, mappings={"ros2_control": "true"}
+        xacro_file_name, mappings={'ros2_control': 'true'}
     ).toxml()
-    assert urdf.find("state_interface") != -1
-    assert urdf.find("command_interface") != -1
-    assert urdf.find("position") != -1
-    assert urdf.find("velocity") != -1
-    assert urdf.find("effort") != -1
+    assert urdf.find('state_interface') != -1
+    assert urdf.find('command_interface') != -1
+    assert urdf.find('position') != -1
+    assert urdf.find('velocity') != -1
+    assert urdf.find('effort') != -1
 
 
 def test_load_with_fake_hardware():
     """Test of use_fake_hardware parameter for ros2_control hardware interface."""
     urdf = xacro.process_file(
-        xacro_file_name, mappings={"ros2_control": "true", "use_fake_hardware": "true"}
+        xacro_file_name, mappings={'ros2_control': 'true', 'use_fake_hardware': 'true'}
     ).toxml()
-    assert urdf.find("fake_components/GenericSystem") != -1
+    assert urdf.find('mock_components/GenericSystem') != -1
 
 
 def test_load_with_robot_ip():
     """Test of robot_ip parameter for ros2_control hardware interface."""
     urdf = xacro.process_file(
         xacro_file_name,
-        mappings={"ros2_control": "true", "robot_ip": "franka_ip_address"},
+        mappings={'ros2_control': 'true', 'robot_ip': 'franka_ip_address'},
     ).toxml()
-    assert urdf.find("franka_ip_address") != -1
+    assert urdf.find('franka_ip_address') != -1
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     pass


### PR DESCRIPTION
Hi～
To use `franka_ros2` on ROS 2 Jazzy, modifications to `franka_description` are also required. The main modifications are as follows:  
1. Change double quotes to single quotes and adjust the import order in Python files to pass `colcon test`;  
2. Modify the `franka_arm.ros2_control.xacro` file (modifications related to Gazebo tags are incompatible because Gazebo has been renamed and its namespace has been adjusted);  
3. Modify the Dockerfile. 