### PR TITLE
allow the mock controller to run for the frank hand, without gazebo

### DIFF
--- a/robots/common/franka_arm.ros2_control.xacro
+++ b/robots/common/franka_arm.ros2_control.xacro
@@ -72,7 +72,7 @@
       <xacro:configure_joint joint_name="${arm_prefix}${robot_type}_joint5" initial_position="0.0"/>
       <xacro:configure_joint joint_name="${arm_prefix}${robot_type}_joint6" initial_position="${pi/2}"/>
       <xacro:configure_joint joint_name="${arm_prefix}${robot_type}_joint7" initial_position="${pi/4}"/>
-      <xacro:if value="${gazebo and hand}">
+      <xacro:if value="${hand}">
         <xacro:configure_joint joint_name="${arm_prefix}${robot_type}_finger_joint1" initial_position="0.0" />
       </xacro:if>
 


### PR DESCRIPTION
The joints in the hand aren't exposed when using the mock ros2 controller. Remove the gazebo condition.