### PR TITLE
Add support for custom controller YAML in Franka ROS2 control

### DIFF
--- a/robots/common/franka_arm.ros2_control.xacro
+++ b/robots/common/franka_arm.ros2_control.xacro
@@ -10,7 +10,7 @@
                  hand:=false
                  gazebo_effort:=false
                  arm_prefix:=''
-                 controller_yaml:='' ">
+                 controller_yaml:='$(find franka_gazebo_bringup)/config/franka_gazebo_controllers.yaml' ">
 
     <xacro:property name="arm_prefix_modified" value="${'' if arm_prefix == '' else arm_prefix + '_'}" />
     <ros2_control name="${arm_prefix_modified}FrankaHardwareInterface" type="system">
@@ -106,14 +106,8 @@
       <gazebo>
         <plugin filename="franka_gz_ros2_control-system" name="gz_ros2_control::GZROS2ControlPlugin">
           
-          <xacro:if value="${controller_yaml != ''}">
-            <parameters>${controller_yaml}</parameters>
-          </xacro:if>
-
-          <xacro:unless value="${controller_yaml != ''}">
-            <parameters>$(find franka_gazebo_bringup)/config/franka_gazebo_controllers.yaml</parameters>
-          </xacro:unless>
-
+          <parameters>${controller_yaml}</parameters>
+      
         </plugin>
       </gazebo>
     </xacro:if>

--- a/robots/common/franka_arm.ros2_control.xacro
+++ b/robots/common/franka_arm.ros2_control.xacro
@@ -9,7 +9,8 @@
                  gazebo:=false
                  hand:=false
                  gazebo_effort:=false
-                 arm_prefix:=''">
+                 arm_prefix:=''
+                 use_default_controller_yaml:=true">
 
     <xacro:property name="arm_prefix_modified" value="${'' if arm_prefix == '' else arm_prefix + '_'}" />
     <ros2_control name="${arm_prefix_modified}FrankaHardwareInterface" type="system">
@@ -104,7 +105,15 @@
     <xacro:if value="${gazebo}">
       <gazebo>
         <plugin filename="franka_gz_ros2_control-system" name="gz_ros2_control::GZROS2ControlPlugin">
+          
+          <xacro:if value="${use_default_controller_yaml}">
           <parameters>$(find franka_gazebo_bringup)/config/franka_gazebo_controllers.yaml</parameters>
+          </xacro:if>
+
+          <xacro:unless value="${use_default_controller_yaml}">
+            <parameters>$(find rox_bringup)/configs/franka/simulation_controllers.yaml</parameters>
+          </xacro:unless>
+
         </plugin>
       </gazebo>
     </xacro:if>

--- a/robots/common/franka_arm.ros2_control.xacro
+++ b/robots/common/franka_arm.ros2_control.xacro
@@ -10,7 +10,7 @@
                  hand:=false
                  gazebo_effort:=false
                  arm_prefix:=''
-                 use_default_controller_yaml:=true">
+                 controller_yaml:='' ">
 
     <xacro:property name="arm_prefix_modified" value="${'' if arm_prefix == '' else arm_prefix + '_'}" />
     <ros2_control name="${arm_prefix_modified}FrankaHardwareInterface" type="system">
@@ -106,12 +106,12 @@
       <gazebo>
         <plugin filename="franka_gz_ros2_control-system" name="gz_ros2_control::GZROS2ControlPlugin">
           
-          <xacro:if value="${use_default_controller_yaml}">
-          <parameters>$(find franka_gazebo_bringup)/config/franka_gazebo_controllers.yaml</parameters>
+          <xacro:if value="${controller_yaml != ''}">
+            <parameters>${controller_yaml}</parameters>
           </xacro:if>
 
-          <xacro:unless value="${use_default_controller_yaml}">
-            <parameters>$(find rox_bringup)/configs/franka/simulation_controllers.yaml</parameters>
+          <xacro:unless value="${controller_yaml != ''}">
+            <parameters>$(find franka_gazebo_bringup)/config/franka_gazebo_controllers.yaml</parameters>
           </xacro:unless>
 
         </plugin>

--- a/robots/common/franka_robot.xacro
+++ b/robots/common/franka_robot.xacro
@@ -28,7 +28,8 @@
                       no_prefix:='false'
                       arm_prefix:=''
                       description_pkg:='franka_description'
-                      connected_to:='base'">
+                      connected_to:='base'
+                      use_default_controller_yaml:=true">
                       
     <xacro:include filename="$(find franka_description)/robots/common/utils.xacro" />
 
@@ -158,12 +159,13 @@
       <xacro:franka_arm_ros2_control
           arm_id="${arm_id}"
           robot_ip="${robot_ip}"
-          use_fake_hardware="${use_fake_hardware}"
+          use_fake_hardware="${use_fake_hardware}" 
           fake_sensor_commands="${fake_sensor_commands}"
           gazebo="${gazebo}"
           hand="${hand}"
           gazebo_effort="${gazebo_effort}"
           arm_prefix="${arm_prefix}"
+          use_default_controller_yaml="${use_default_controller_yaml}"
       />
     </xacro:if>
 

--- a/robots/common/franka_robot.xacro
+++ b/robots/common/franka_robot.xacro
@@ -29,7 +29,7 @@
                       arm_prefix:=''
                       description_pkg:='franka_description'
                       connected_to:='base'
-                      use_default_controller_yaml:=true">
+                      controller_yaml:='' ">
                       
     <xacro:include filename="$(find franka_description)/robots/common/utils.xacro" />
 
@@ -165,7 +165,7 @@
           hand="${hand}"
           gazebo_effort="${gazebo_effort}"
           arm_prefix="${arm_prefix}"
-          use_default_controller_yaml="${use_default_controller_yaml}"
+          controller_yaml="${controller_yaml}"
       />
     </xacro:if>
 


### PR DESCRIPTION
Description:
This change introduces a new argument controller_yaml in the Franka arm ROS2 control and Franka_Robot xacro files. When set , users can provide a custom controller YAML file instead of the default example controllers.