### PR TITLE
Standard bash shebang

### DIFF
--- a/scripts/create_urdf.sh
+++ b/scripts/create_urdf.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 docker build -t urdf_creation \
     --build-arg USER_UID=$(id -u) \

--- a/scripts/visualize_franka.sh
+++ b/scripts/visualize_franka.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 docker build -t urdf_creation \
     --build-arg USER_UID=$(id -u) \


### PR DESCRIPTION
On some systems (e.g NixOS), using a hardcoded shebang causes issues, this PR uses a standard portable shebang instead.