### PR TITLE
Cobot Pump collision in moveit

### DIFF
--- a/end_effectors/cobot_pump/cobot_pump.srdf.xacro
+++ b/end_effectors/cobot_pump/cobot_pump.srdf.xacro
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='utf-8'?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:macro name="cobot_pump_srdf" params="prefix">
+
+    <disable_collisions link1="${prefix}cobot_pump" link2="${prefix}link7" reason="Adjacent"/>
+    <disable_collisions link1="${prefix}cobot_pump" link2="${prefix}link8" reason="Adjacent"/>
+
+  </xacro:macro>
+</robot>

--- a/robots/common/franka_arm.srdf.xacro
+++ b/robots/common/franka_arm.srdf.xacro
@@ -37,6 +37,10 @@
                 <xacro:include filename="$(find franka_description)/end_effectors/franka_hand/franka_hand.srdf.xacro"/>
                 <xacro:franka_hand_srdf prefix="${prefix}"/>
             </xacro:if>
+            <xacro:if value="${ee_id == 'cobot_pump'}">
+                <xacro:include filename="$(find franka_description)/end_effectors/cobot_pump/cobot_pump.srdf.xacro"/>
+                <xacro:cobot_pump_srdf prefix="${prefix}"/>
+            </xacro:if>
         </xacro:if>
 
     </xacro:macro>


### PR DESCRIPTION
When launching moveit with:

```
ros2 launch franka_fr3_moveit_config server_moveit.launch.py robot_ip:=IP load_gripper:=true ee_id:=cobot_pump
```

The cobot pump loads fine but trying to perform motion planning fails because the pump is in collision and the whole pump mesh is red. This PR adds ignore collisions between the cobot pump and some of the robot links to solve this issue. With these changes, the cobot pump and moveit works fine.