### PR TITLE
Set velocity state initial value

### DIFF
--- a/robots/common/franka_arm.ros2_control.xacro
+++ b/robots/common/franka_arm.ros2_control.xacro
@@ -58,8 +58,9 @@
           <state_interface name="position">
             <param name="initial_value">${initial_position}</param>
           </state_interface>
-          <state_interface name="velocity"/>
+          <state_interface name="velocity">
             <param name="initial_value">0.0</param>
+          </state_interface>
           <state_interface name="effort"/>
         </joint>
       </xacro:macro>


### PR DESCRIPTION
Minor bug in the franka arm ros2_control macro where the initial value for the velocity state interface was not being set.